### PR TITLE
Bulk query of epochs against /epochStatus

### DIFF
--- a/data_models.py
+++ b/data_models.py
@@ -29,6 +29,11 @@ class SnapshotBase(PeerUUIDIncludedRequests):
     projectID: str
 
 
+class EpochStatusRequest(PeerUUIDIncludedRequests):
+    projectID: str
+    epochs: List[EpochBase]
+
+
 class SnapshotSubmission(SnapshotBase):
     snapshotCID: str
 


### PR DESCRIPTION
…e self healing in DAG finalizer

<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #20 

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

---

### Current behaviour
<!-- Describe the code you are going to change and its behaviour -->
Offchain consensus service opens up an API endpoint, /epochStatus, which is used by the DAG finalizer component in Audit Protocol to perform self-healing of the DAG chain of snapshots maintained by each individual snapshotter. This supports only one epoch to be queried at a time.

https://github.com/PowerLoom/offchain-consensus/blob/c2aff8827941c02c1bc15852e8e5fea258fbd465/consensus_entry_point.py#L300-L315

At the moment, if there are multitude of chains along with a large span of blocks corresponding to the local state of a snapshotter that have fallen behind, the self-healing feature would cause a flood of requests to the above endpoint thereby hitting rate limits imposed on snapshotter API requests and finally causing the self healing to fail.

---

### New expected behaviour
<!-- Describe the new code and its expected behaviour -->

Now it is supported to pass an array of epochs in the above request. Like the following:

```python
@app.post('/epochStatus')
async def epoch_status(
        request: Request,
        req_parsed: EpochStatusRequest,
        response: Response,
        rate_limit_auth_dep: RateLimitAuthCheck = Depends(rate_limit_auth_check)
)

class EpochStatusRequest(PeerUUIDIncludedRequests):
    projectID: str
    epochs: List[EpochBase]

```
---

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->

---

<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
API request model for `/epochStatus`
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
Restart `consensus_entry_point` when no snapshots are being submitted.